### PR TITLE
 Long press 'a' key to repeatedly type 'a'

### DIFF
--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
@@ -66,6 +66,7 @@ class AaaaaInputMethodService : InputMethodService(), AaaaaKeyboardView.AaaaaKey
     }
 
     override fun onLongA() {
+        longPressThread?.interrupt()
         longPressThread = newLongPressThread()
     }
 

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
@@ -10,16 +10,28 @@ package io.github.dkter.aaaaa
 
 import android.inputmethodservice.InputMethodService
 import android.text.TextUtils
-import android.util.Log
 import android.view.KeyEvent
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
 import kotlin.concurrent.thread
 
-class AaaaaInputMethodService:
-    InputMethodService(),
-    AaaaaKeyboardView.AaaaaKeyboardListener {
+class AaaaaInputMethodService : InputMethodService(), AaaaaKeyboardView.AaaaaKeyboardListener {
+
+    private fun makeLongPressThread() = thread(start = false) {
+        while (!Thread.currentThread().isInterrupted) {
+            val uppercase = (0..1).random() == 1
+            inputChar(if (uppercase) 'A' else 'a')
+            try {
+                Thread.sleep(100L)
+            } catch (e: InterruptedException) {
+                break
+            }
+        }
+    }
+
+    private var longPressThread: Thread? = null
+
     override fun onCreateInputView(): View {
         val keyboardView = AaaaaKeyboardView(
             context=this,
@@ -45,11 +57,11 @@ class AaaaaInputMethodService:
     }
 
     override fun onPressA() {
-
+        longPressThread = makeLongPressThread().apply { start() }
     }
 
     override fun onReleaseA() {
-        inputChar('a')
+        longPressThread?.interrupt()
     }
 
     override fun onBackspace() {

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
@@ -58,6 +58,14 @@ class AaaaaInputMethodService:
         }
     }
 
+    override fun onPressA() {
+
+    }
+
+    override fun onReleaseA() {
+        onA()
+    }
+
     override fun onBackspace() {
         val ic: InputConnection? = getCurrentInputConnection()
         if (ic == null) {

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
@@ -20,8 +20,7 @@ class AaaaaInputMethodService : InputMethodService(), AaaaaKeyboardView.AaaaaKey
 
     private fun newLongPressThread() = thread {
         while (!Thread.currentThread().isInterrupted) {
-            val uppercase = (0..1).random() == 1
-            inputChar(if (uppercase) 'A' else 'a')
+            inputChar('a')
             try {
                 Thread.sleep(100L)
             } catch (e: InterruptedException) {

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
@@ -18,7 +18,7 @@ import kotlin.concurrent.thread
 
 class AaaaaInputMethodService : InputMethodService(), AaaaaKeyboardView.AaaaaKeyboardListener {
 
-    private fun makeLongPressThread() = thread(start = false) {
+    private fun newLongPressThread() = thread {
         while (!Thread.currentThread().isInterrupted) {
             val uppercase = (0..1).random() == 1
             inputChar(if (uppercase) 'A' else 'a')
@@ -57,7 +57,7 @@ class AaaaaInputMethodService : InputMethodService(), AaaaaKeyboardView.AaaaaKey
     }
 
     override fun onPressA() {
-        longPressThread = makeLongPressThread().apply { start() }
+        longPressThread = newLongPressThread()
     }
 
     override fun onReleaseA() {

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
@@ -48,6 +48,11 @@ class AaaaaInputMethodService : InputMethodService(), AaaaaKeyboardView.AaaaaKey
         setInputView(onCreateInputView())
     }
 
+    override fun onFinishInputView(finishingInput: Boolean) {
+        super.onFinishInputView(finishingInput)
+        longPressThread?.interrupt()
+    }
+
     private fun inputChar(ch: Char) {
         val ic: InputConnection? = getCurrentInputConnection()
         if (ic == null) {

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
@@ -15,6 +15,7 @@ import android.view.KeyEvent
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
+import kotlin.concurrent.thread
 
 class AaaaaInputMethodService:
     InputMethodService(),
@@ -48,9 +49,12 @@ class AaaaaInputMethodService:
     }
 
     override fun onLongA() {
-        for (i in 0..25) {
-            val uppercase = (0..1).random() == 1
-            inputChar(if (uppercase) 'A' else 'a')
+        thread {
+            for (i in 0..25) {
+                val uppercase = (0..1).random() == 1
+                inputChar(if (uppercase) 'A' else 'a')
+                Thread.sleep(100L)
+            }
         }
     }
 

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
@@ -56,6 +56,20 @@ class AaaaaInputMethodService : InputMethodService(), AaaaaKeyboardView.AaaaaKey
         ic.commitText(ch.toString(), 1)
     }
 
+    override fun onA() {
+        inputChar('a')
+    }
+
+    override fun onLongA() {
+        thread {
+            for (i in 0..25) {
+                val uppercase = (0..1).random() == 1
+                inputChar(if (uppercase) 'A' else 'a')
+                Thread.sleep(100L)
+            }
+        }
+    }
+
     override fun onPressA() {
         longPressThread = newLongPressThread()
     }

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
@@ -47,6 +47,10 @@ class AaaaaInputMethodService:
         inputChar('a')
     }
 
+    override fun onLongA() {
+        TODO("Not yet implemented")
+    }
+
     override fun onBackspace() {
         val ic: InputConnection? = getCurrentInputConnection()
         if (ic == null) {

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
@@ -48,7 +48,10 @@ class AaaaaInputMethodService:
     }
 
     override fun onLongA() {
-        TODO("Not yet implemented")
+        for (i in 0..25) {
+            val uppercase = (0..1).random() == 1
+            inputChar(if (uppercase) 'A' else 'a')
+        }
     }
 
     override fun onBackspace() {

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
@@ -61,16 +61,6 @@ class AaaaaInputMethodService : InputMethodService(), AaaaaKeyboardView.AaaaaKey
     }
 
     override fun onLongA() {
-        thread {
-            for (i in 0..25) {
-                val uppercase = (0..1).random() == 1
-                inputChar(if (uppercase) 'A' else 'a')
-                Thread.sleep(100L)
-            }
-        }
-    }
-
-    override fun onPressA() {
         longPressThread = newLongPressThread()
     }
 

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaInputMethodService.kt
@@ -44,26 +44,12 @@ class AaaaaInputMethodService:
         ic.commitText(ch.toString(), 1)
     }
 
-    override fun onA() {
-        inputChar('a')
-    }
-
-    override fun onLongA() {
-        thread {
-            for (i in 0..25) {
-                val uppercase = (0..1).random() == 1
-                inputChar(if (uppercase) 'A' else 'a')
-                Thread.sleep(100L)
-            }
-        }
-    }
-
     override fun onPressA() {
 
     }
 
     override fun onReleaseA() {
-        onA()
+        inputChar('a')
     }
 
     override fun onBackspace() {

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaKeyboardView.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaKeyboardView.kt
@@ -8,6 +8,7 @@
 
 package io.github.dkter.aaaaa
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
 import android.view.*
@@ -16,6 +17,7 @@ import android.widget.ImageButton
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.preference.PreferenceManager
 
+@SuppressLint("ClickableViewAccessibility")
 class AaaaaKeyboardView(
     context: Context,
     keyboardListener: AaaaaKeyboardListener,
@@ -72,7 +74,7 @@ class AaaaaKeyboardView(
         this.btnReturn = findViewById<ImageButton>(R.id.btnReturn)
 
         this.btnA.setOnLongClickListener(this)
-        this.btnA.setOnTouchListener(this) // TODO accessibility
+        this.btnA.setOnTouchListener(this)
         this.btnA.setOnClickListener(this)
         this.btnBackspace.setOnClickListener(this)
         this.btnSpace.setOnClickListener(this)

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaKeyboardView.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaKeyboardView.kt
@@ -10,7 +10,6 @@ package io.github.dkter.aaaaa
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.util.Log
 import android.view.*
 import android.widget.Button
 import android.widget.ImageButton
@@ -20,11 +19,8 @@ import androidx.preference.PreferenceManager
 class AaaaaKeyboardView(
     context: Context,
     keyboardListener: AaaaaKeyboardListener,
-) : ConstraintLayout(context), View.OnClickListener, View.OnLongClickListener,
-    View.OnTouchListener {
+) : ConstraintLayout(context), View.OnClickListener, View.OnTouchListener {
     interface AaaaaKeyboardListener {
-        fun onA()
-        fun onLongA()
         fun onPressA()
         fun onReleaseA()
         fun onBackspace()
@@ -73,12 +69,9 @@ class AaaaaKeyboardView(
         this.btnSpace = findViewById<Button>(R.id.btnSpace)
         this.btnReturn = findViewById<ImageButton>(R.id.btnReturn)
 
-        this.btnA.setOnClickListener(this)
         this.btnBackspace.setOnClickListener(this)
         this.btnSpace.setOnClickListener(this)
         this.btnReturn.setOnClickListener(this)
-
-        this.btnA.setOnLongClickListener(this)
         this.btnA.setOnTouchListener(this)
 
         this.keyboardListener = keyboardListener
@@ -96,10 +89,6 @@ class AaaaaKeyboardView(
         val id = v.getId()
         if (this.getBooleanPref(R.string.hapticFeedbackKey))
             v.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
-
-        if (id == R.id.btnA) {
-            this.keyboardListener.onA()
-        }
         else if (id == R.id.btnBackspace) {
             this.keyboardListener.onBackspace()
         }
@@ -109,14 +98,6 @@ class AaaaaKeyboardView(
         else if (id == R.id.btnReturn) {
             this.keyboardListener.onReturn()
         }
-    }
-
-    override fun onLongClick(v: View): Boolean {
-        val id = v.getId()
-        if (id == R.id.btnA) {
-            this.keyboardListener.onLongA()
-        }
-        return true
     }
 
     override fun onTouch(v: View?, event: MotionEvent?): Boolean {

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaKeyboardView.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaKeyboardView.kt
@@ -71,13 +71,12 @@ class AaaaaKeyboardView(
         this.btnSpace = findViewById<Button>(R.id.btnSpace)
         this.btnReturn = findViewById<ImageButton>(R.id.btnReturn)
 
+        this.btnA.setOnLongClickListener(this)
+        this.btnA.setOnTouchListener(this) // TODO accessibility
         this.btnA.setOnClickListener(this)
         this.btnBackspace.setOnClickListener(this)
         this.btnSpace.setOnClickListener(this)
         this.btnReturn.setOnClickListener(this)
-
-        this.btnA.setOnLongClickListener(this)
-        this.btnA.setOnTouchListener(this)
 
         this.keyboardListener = keyboardListener
     }

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaKeyboardView.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaKeyboardView.kt
@@ -80,6 +80,8 @@ class AaaaaKeyboardView(
         this.btnSpace.setOnClickListener(this)
         this.btnReturn.setOnClickListener(this)
 
+        this.btnA.setOnLongClickListener(this)
+
         this.keyboardListener = keyboardListener
     }
 

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaKeyboardView.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaKeyboardView.kt
@@ -25,9 +25,10 @@ import androidx.preference.PreferenceManager
 class AaaaaKeyboardView(
     context: Context,
     keyboardListener: AaaaaKeyboardListener,
-): ConstraintLayout(context), View.OnClickListener {
+): ConstraintLayout(context), View.OnClickListener, View.OnLongClickListener {
     interface AaaaaKeyboardListener {
         fun onA()
+        fun onLongA()
         fun onBackspace()
         fun onSpace()
         fun onReturn()
@@ -107,5 +108,13 @@ class AaaaaKeyboardView(
         else if (id == R.id.btnReturn) {
             this.keyboardListener.onReturn()
         }
+    }
+
+    override fun onLongClick(v: View): Boolean {
+        val id = v.getId()
+        if (id == R.id.btnA) {
+            this.keyboardListener.onLongA()
+        }
+        return true
     }
 }

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaKeyboardView.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaKeyboardView.kt
@@ -10,6 +10,7 @@ package io.github.dkter.aaaaa
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
 import android.view.*
 import android.widget.Button
 import android.widget.ImageButton
@@ -19,8 +20,11 @@ import androidx.preference.PreferenceManager
 class AaaaaKeyboardView(
     context: Context,
     keyboardListener: AaaaaKeyboardListener,
-) : ConstraintLayout(context), View.OnClickListener, View.OnTouchListener {
+) : ConstraintLayout(context), View.OnClickListener, View.OnLongClickListener,
+    View.OnTouchListener {
     interface AaaaaKeyboardListener {
+        fun onA()
+        fun onLongA()
         fun onPressA()
         fun onReleaseA()
         fun onBackspace()
@@ -69,9 +73,12 @@ class AaaaaKeyboardView(
         this.btnSpace = findViewById<Button>(R.id.btnSpace)
         this.btnReturn = findViewById<ImageButton>(R.id.btnReturn)
 
+        this.btnA.setOnClickListener(this)
         this.btnBackspace.setOnClickListener(this)
         this.btnSpace.setOnClickListener(this)
         this.btnReturn.setOnClickListener(this)
+
+        this.btnA.setOnLongClickListener(this)
         this.btnA.setOnTouchListener(this)
 
         this.keyboardListener = keyboardListener
@@ -89,6 +96,10 @@ class AaaaaKeyboardView(
         val id = v.getId()
         if (this.getBooleanPref(R.string.hapticFeedbackKey))
             v.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+
+        if (id == R.id.btnA) {
+            this.keyboardListener.onA()
+        }
         else if (id == R.id.btnBackspace) {
             this.keyboardListener.onBackspace()
         }
@@ -98,6 +109,14 @@ class AaaaaKeyboardView(
         else if (id == R.id.btnReturn) {
             this.keyboardListener.onReturn()
         }
+    }
+
+    override fun onLongClick(v: View): Boolean {
+        val id = v.getId()
+        if (id == R.id.btnA) {
+            this.keyboardListener.onLongA()
+        }
+        return true
     }
 
     override fun onTouch(v: View?, event: MotionEvent?): Boolean {

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaKeyboardView.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaKeyboardView.kt
@@ -10,7 +10,6 @@ package io.github.dkter.aaaaa
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.util.Log
 import android.view.*
 import android.widget.Button
 import android.widget.ImageButton
@@ -25,7 +24,6 @@ class AaaaaKeyboardView(
     interface AaaaaKeyboardListener {
         fun onA()
         fun onLongA()
-        fun onPressA()
         fun onReleaseA()
         fun onBackspace()
         fun onSpace()
@@ -113,23 +111,18 @@ class AaaaaKeyboardView(
 
     override fun onLongClick(v: View): Boolean {
         val id = v.getId()
-        if (id == R.id.btnA) {
+        return if (id == R.id.btnA) {
             this.keyboardListener.onLongA()
-        }
-        return true
+            true
+        } else false
     }
 
     override fun onTouch(v: View?, event: MotionEvent?): Boolean {
         val id = v?.id
         val action = event?.action
-        if (id == R.id.btnA) {
-            when (action) {
-                MotionEvent.ACTION_CANCEL -> return false
-                MotionEvent.ACTION_DOWN -> keyboardListener.onPressA()
-                MotionEvent.ACTION_UP -> keyboardListener.onReleaseA()
-            }
-            return true
-        }
+
+        if (id == R.id.btnA && action == MotionEvent.ACTION_UP) keyboardListener.onReleaseA()
+
         return false
     }
 }

--- a/app/src/main/java/io/github/dkter/aaaaa/AaaaaKeyboardView.kt
+++ b/app/src/main/java/io/github/dkter/aaaaa/AaaaaKeyboardView.kt
@@ -10,25 +10,23 @@ package io.github.dkter.aaaaa
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.util.AttributeSet
-import android.view.ContextThemeWrapper
-import android.view.HapticFeedbackConstants
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
+import android.util.Log
+import android.view.*
 import android.widget.Button
 import android.widget.ImageButton
-
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.preference.PreferenceManager
 
 class AaaaaKeyboardView(
     context: Context,
     keyboardListener: AaaaaKeyboardListener,
-): ConstraintLayout(context), View.OnClickListener, View.OnLongClickListener {
+) : ConstraintLayout(context), View.OnClickListener, View.OnLongClickListener,
+    View.OnTouchListener {
     interface AaaaaKeyboardListener {
         fun onA()
         fun onLongA()
+        fun onPressA()
+        fun onReleaseA()
         fun onBackspace()
         fun onSpace()
         fun onReturn()
@@ -81,6 +79,7 @@ class AaaaaKeyboardView(
         this.btnReturn.setOnClickListener(this)
 
         this.btnA.setOnLongClickListener(this)
+        this.btnA.setOnTouchListener(this)
 
         this.keyboardListener = keyboardListener
     }
@@ -118,5 +117,19 @@ class AaaaaKeyboardView(
             this.keyboardListener.onLongA()
         }
         return true
+    }
+
+    override fun onTouch(v: View?, event: MotionEvent?): Boolean {
+        val id = v?.id
+        val action = event?.action
+        if (id == R.id.btnA) {
+            when (action) {
+                MotionEvent.ACTION_CANCEL -> return false
+                MotionEvent.ACTION_DOWN -> keyboardListener.onPressA()
+                MotionEvent.ACTION_UP -> keyboardListener.onReleaseA()
+            }
+            return true
+        }
+        return false
     }
 }


### PR DESCRIPTION
This pull request implements the feature request from issue #11. I haven't made capital 'A's optional yet, but I can implement that, if you want me to.

I realized this code can be used for the backspace button as well, so you don't have to repeatedly click it to delete text. I might open up a seperate pull request for that later.

The current implementation simply creates a new background thread for typing out 'a's asynchronously, but I think it might be better to use kotlin coroutines to improve code quality and app performance. I'll leave that up to you to decide.